### PR TITLE
Add unit test for draw_snake

### DIFF
--- a/main.py
+++ b/main.py
@@ -139,4 +139,5 @@ def run_game() -> None:
     quit()
 
 
-run_game()
+if __name__ == "__main__":
+    run_game()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 python = "^3.11"
 pygame = "^2.5.2"
 
+[tool.poetry.dev-dependencies]
+pytest = "^7.4"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_draw_snake.py
+++ b/tests/test_draw_snake.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+# Use dummy video driver for headless testing
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pygame
+import main
+
+
+def test_draw_snake_invokes_rect_for_each_segment():
+    main.game_display = pygame.Surface((100, 100))
+    coords = [[0, 0], [10, 10], [20, 20]]
+    with patch("pygame.draw.rect") as mock_rect:
+        main.draw_snake(10, coords)
+        assert mock_rect.call_count == len(coords)


### PR DESCRIPTION
## Summary
- ensure running the game only when executing `main.py` directly
- add pytest to development dependencies
- test that `draw_snake` draws each snake segment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f627eeb50832398e6fd96aab97472